### PR TITLE
feat: Update device naming from HC-05 to sEMG

### DIFF
--- a/app/models/BluetoothStoreLite.ts
+++ b/app/models/BluetoothStoreLite.ts
@@ -82,7 +82,7 @@ export const BluetoothStoreLiteModel = types
 
       const deviceName = self.selectedDevice.name.toLowerCase()
 
-      if (deviceName.includes("hc-05") || deviceName.includes("hc05")) {
+      if (deviceName.includes("hc-05") || deviceName.includes("hc05") || deviceName.includes("semg_")) {
         return "HC-05"
       }
 

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -133,7 +133,7 @@ export const HomeScreen: FC<DemoTabScreenProps<"Home">> = observer(function Home
                             ]}
                           >
                             <Text
-                              text={item.deviceType}
+                              text={item.deviceType === "HC-05" ? "sEMG" : item.deviceType}
                               style={[$deviceTypeText, { color: colors.background }]}
                             />
                           </View>

--- a/app/screens/SessionDetailScreen.tsx
+++ b/app/screens/SessionDetailScreen.tsx
@@ -454,7 +454,7 @@ export const SessionDetailScreen: FC<AppStackScreenProps<"SessionDetail">> = obs
                   ]}
                 >
                   <Text
-                    text={sessionData.deviceType}
+                    text={sessionData.deviceType === "HC-05" ? "sEMG" : sessionData.deviceType}
                     style={[$deviceTypeText, { color: colors.background }]}
                   />
                 </View>

--- a/app/screens/UserSessionsListScreen.tsx
+++ b/app/screens/UserSessionsListScreen.tsx
@@ -183,7 +183,7 @@ export const UserSessionsListScreen: FC<AppStackScreenProps<"UserSessionsList">>
                   ]}
                 >
                   <Text
-                    text={item.deviceType}
+                    text={item.deviceType === "HC-05" ? "sEMG" : item.deviceType}
                     style={[$deviceTypeText, { color: colors.background }]}
                   />
                 </View>

--- a/app/services/BluetoothDataService.ts
+++ b/app/services/BluetoothDataService.ts
@@ -228,7 +228,7 @@ export class BluetoothDataService {
       // Detect device type based on device name
       const deviceName = this.selectedDevice.name || "Unknown"
       let deviceType: "HC-05" | "IMU" | null = null
-      if (deviceName.toLowerCase().includes("hc-05") || deviceName.toLowerCase().includes("hc05")) {
+      if (deviceName.toLowerCase().includes("hc-05") || deviceName.toLowerCase().includes("hc05") || deviceName.toLowerCase().includes("semg_")) {
         deviceType = "HC-05"
       } else if (deviceName.toLowerCase().includes("imu")) {
         deviceType = "IMU"
@@ -677,7 +677,8 @@ export class BluetoothDataService {
         let deviceType: "HC-05" | "IMU" | null = null
         if (
           deviceName.toLowerCase().includes("hc-05") ||
-          deviceName.toLowerCase().includes("hc05")
+          deviceName.toLowerCase().includes("hc05") ||
+          deviceName.toLowerCase().includes("semg_")
         ) {
           deviceType = "HC-05"
         } else if (deviceName.toLowerCase().includes("imu")) {


### PR DESCRIPTION
- Add support for sEMG_ prefix in device detection
- Update UI to display "sEMG" instead of "HC-05"
- Maintain backward compatibility with existing HC-05 devices

Changes:
- BluetoothDataService: Add semg_ prefix detection
- BluetoothStoreLite: Add semg_ prefix detection
- UI screens: Display "sEMG" for HC-05 device type